### PR TITLE
Add Github Actions build on Windows and apply minor Github Actions updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,14 +6,14 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Setup environment
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get update
         sudo apt-get install texlive*
-    - name: Update submodules
-      run: git submodule update --init --recursive
     - name: Build
       run: |
         mkdir build
@@ -22,7 +22,29 @@ jobs:
         cmake --build . 
         cd ..
       shell: bash
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ubuntu-artifacts
+        path: build/bin/
+  windows-build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Setup environment
+      run: |
+        choco install miktex --no-progress
+        echo "C:\Program Files\MiKTeX\miktex\bin\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake -D USE_LATEX=ON  ..
+        cmake --build . 
+        cd ..
+      shell: bash
+    - uses: actions/upload-artifact@v4
+      with:
+        name: windows-artifacts
         path: build/bin/


### PR DESCRIPTION
- Add Github Actions based build for LaTeX
- Remove an additional step of checking out submodules and add perform it as a part of actions/checkout
- Update actions/upload-artifact action version (v2 is deprecated)