### PR TITLE
Update badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/5hies4gp7lyrxs8n/branch/master?svg=true)](https://ci.appveyor.com/project/allnes/programming-course-reports/branch/master)
-![Build application](https://github.com/learning-process/programming_course_reports/workflows/Build%20application/badge.svg?branch=master)
+[![Build application](https://github.com/learning-process/programming_course_reports/actions/workflows/main.yml/badge.svg)](https://github.com/learning-process/programming_course_reports/actions/workflows/main.yml)
 
 # Programming Course Reports
 


### PR DESCRIPTION
GitHub updated the path for workflow badges a long time ago: https://github.com/github/docs/pull/3802/files#diff-95d58394efa588c4f92f85274259efb8ca1e10a02bd346549e65b57604c156c4
Docs: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge
Old link became outdated, and it shows old status all the time